### PR TITLE
Re-copy libva drivers and required libraries after updating plex

### DIFF
--- a/root/etc/cont-init.d/60-plex-update
+++ b/root/etc/cont-init.d/60-plex-update
@@ -125,3 +125,10 @@ else
 dpkg -i --force-confold /tmp/plexmediaserver_"${REMOTE_VERSION}"_${PLEX_ARCH}.deb
 rm -f /tmp/plexmediaserver_*.deb
 fi
+
+cp /lib/x86_64-linux-gnu/dri/radeonsi_drv_video.so /usr/lib/plexmediaserver/lib/dri/
+cp /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1.* /usr/lib/plexmediaserver/lib/libdrm_amdgpu.so.1
+cp /lib/x86_64-linux-gnu/libdrm.so.2.* /usr/lib/plexmediaserver/lib/libdrm.so.2
+cp /lib/x86_64-linux-gnu/libva-drm.so.2.* /usr/lib/plexmediaserver/lib/libva-drm.so.2
+cp /lib/x86_64-linux-gnu/libva.so.2.* /usr/lib/plexmediaserver/lib/libva.so.2
+cp /lib/x86_64-linux-gnu/libstdc++.so.6.* /usr/lib/plexmediaserver/lib/libstdc++.so.6


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-plex/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

-----------------------------

## Description:
My setup for running plex is configured to use the "latest" version which invokes a script on container start that downloads the latest version available, including plex pass-only versions. This tramples over the libraries for AMD HW transcoding that get copied in to the plex libraries directories. Adding the same copies at the end of the script keeps any automatic updates from breaking HW transcoding.

## Benefits of this PR and context:
AMD hardware transcoding won't break when the docker container automatically updates plex.

## How Has This Been Tested?
1. Built the container from mauimauer/docker-plex:ryzen and ran it with VERSION=latest, transcoded a video, got an error that GLIBCXX 3.4.26 was not found and fell back to software transcode.
2. Recreated the container with VERSION=docker, transcoding was successful in HW
3. Added the cp commands to the end .../cont-init.d/60-plex-update
4. Rebuilt the image, ran the container with VERSION=latest, HW transcoding now successful
